### PR TITLE
Change the python folder name

### DIFF
--- a/kieker.otel.translation.parent/kieker.otel.translation/src/kieker/otel/translation/generator/OtktGenerator.xtend
+++ b/kieker.otel.translation.parent/kieker.otel.translation/src/kieker/otel/translation/generator/OtktGenerator.xtend
@@ -75,7 +75,7 @@ class OtktGenerator extends AbstractGenerator {
 		// instatiate kiekerexporter generator
 		val pythonExporterGen = new PythonOtelSdkGenerator(records, otelSpan, mappingList)
 		val result = pythonExporterGen.generate()
-		fsa.generateFile('python/kiekerexporter.py', result)
+		fsa.generateFile('otkt/kiekerexporter.py', result)
         
         var OtelInitGenerator otelInit = new OtelInitGenerator(true)
 		// instatiate kiekerprocessor generator, 
@@ -86,12 +86,12 @@ class OtktGenerator extends AbstractGenerator {
 			val pythonProcessorGen = new PythonProcessorSdk(globalyModifiedAttributes, parentlyModifiedAttributes,
 				globalModified, parentModified)
 			val resultProcessor = pythonProcessorGen.generate()
-			fsa.generateFile('python/kiekerprocessor.py', resultProcessor)
-			fsa.generateFile('python/otelinit.py', otelInit.generate)
+			fsa.generateFile('otkt/kiekerprocessor.py', resultProcessor)
+			fsa.generateFile('otkt/otelinit.py', otelInit.generate)
 
 		}else{
 			otelInit.setGenerateProcessor(false)
-			fsa.generateFile('python/otelinit.py', otelInit.generate)
+			fsa.generateFile('otkt/otelinit.py', otelInit.generate)
 		}
 		
 

--- a/kieker.otel.translation.parent/kieker.otel.translation/src/kieker/otel/translation/generator/python/OtelInitGenerator.xtend
+++ b/kieker.otel.translation.parent/kieker.otel.translation/src/kieker/otel/translation/generator/python/OtelInitGenerator.xtend
@@ -15,8 +15,8 @@ class OtelInitGenerator implements IPythonGenerator{
 		from opentelemetry.sdk.trace import TracerProvider
 		from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor
 		
-		from kiekerexporter import KiekerTcpExporter
-		from kiekerprocessor import IncrementAttributeSpanProcessor
+		from otkt.kiekerexporter import KiekerTcpExporter
+		from otkt.kiekerprocessor import IncrementAttributeSpanProcessor
 		
 		trace.set_tracer_provider(TracerProvider())
 		


### PR DESCRIPTION
Hi Serafim,

We can export the PYTHONPATH environment variable and keep all Otkt python modules in one place. I suggest we use the folder name otkt instead of python.

python -> otkt