### PR TITLE
Added the logback logging backend for  collector

### DIFF
--- a/kieker.otel.translation.parent/kieker.otel.translation/src/kieker/otel/translation/generator/analysis/PomGenerator.xtend
+++ b/kieker.otel.translation.parent/kieker.otel.translation/src/kieker/otel/translation/generator/analysis/PomGenerator.xtend
@@ -115,6 +115,12 @@ class PomGenerator {
 				<artifactId>jaxb-impl</artifactId>
 				<version>4.0.5</version>
 				</dependency>
+				</dependency>
+				<dependency>
+				<groupId>ch.qos.logback</groupId>
+				<artifactId>logback-classic</artifactId>
+				<version>1.5.15</version>
+				</dependency>
 			</dependencies>
 				
 				</project>'''


### PR DESCRIPTION
Hi Serafim,

The current collector prints warnings for no logging backend.

```
SLF4J(W): No SLF4J providers were found.
SLF4J(W): Defaulting to no-operation (NOP) logger implementation
SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
```

This PR fixes the issue.